### PR TITLE
Build info

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/intercloud/gobinsec
 
-go 1.17
+go 1.18
 
 require (
 	github.com/bradfitz/gomemcache v0.0.0-20220106215444-fb4bf637b56d
@@ -13,5 +13,5 @@ require (
 require (
 	github.com/mattn/go-colorable v0.1.12 // indirect
 	github.com/mattn/go-isatty v0.0.14 // indirect
-	golang.org/x/sys v0.0.0-20220408201424-a24fb2fb8a0f // indirect
+	golang.org/x/sys v0.0.0-20220412211240-33da011f77ad // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -16,8 +16,8 @@ golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220408201424-a24fb2fb8a0f h1:8w7RhxzTVgUzw/AH/9mUV5q0vMgy40SQRursCcfmkCw=
-golang.org/x/sys v0.0.0-20220408201424-a24fb2fb8a0f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220412211240-33da011f77ad h1:ntjMns5wyP/fN65tdBD4g8J5w8n015+iIIs9rtjXkY0=
+golang.org/x/sys v0.0.0-20220412211240-33da011f77ad/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b h1:h8qDotaEPuJATrMmW04NCwg7v22aHH28wwpauUhK9Oo=

--- a/gobinsec/binary.go
+++ b/gobinsec/binary.go
@@ -1,13 +1,13 @@
 package gobinsec
 
 import (
+	"debug/buildinfo"
 	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
 	"sync"
-	"debug/buildinfo"
 )
 
 const (

--- a/gobinsec/binary.go
+++ b/gobinsec/binary.go
@@ -46,6 +46,9 @@ func (b *Binary) GetDependencies() error {
 		return err
 	}
 	for _, dep := range info.Deps {
+		for dep.Replace != nil {
+			dep = dep.Replace
+		}
 		dependency, err := NewDependency(dep.Path, dep.Version)
 		if err != nil {
 			return err

--- a/gobinsec/dependency.go
+++ b/gobinsec/dependency.go
@@ -38,7 +38,7 @@ func (d *Dependency) LoadVulnerabilities() error {
 		if config.APIKey != "" {
 			url += "&apiKey=" + config.APIKey
 		}
-		response, err := http.Get(url) // nolint:noctx,gosec // it's safe!
+		response, err := http.Get(url) // nolint:gosec // it's safe!
 		if err != nil {
 			return fmt.Errorf("calling NVD: %v", err)
 		}


### PR DESCRIPTION
Using _buildinfo_ to get information about embedded dependencies instead of calling `go version -m`.