### PR TITLE
Added cache logging anf timeout configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,12 @@ This tool parses Go binary dependencies and calls [NVD database](https://nvd.nis
     - [Memcachier](#memcachier)
     - [Memcached](#memcached)
     - [File](#file)
-5. [Versions](#versions)
-6. [How to Fix Vulnerabilities](#how-to-fix-vulnerabilities)
-7. [Information about vulnerabilities](#information-about-vulnerabilities)
-8. [How Gobinsec works](#how-gobinsec-works)
-9. [License](#license)
+5. [Timeout and Expiration](#timeout-and-expiration)
+6. [Versions](#versions)
+7. [How to Fix Vulnerabilities](#how-to-fix-vulnerabilities)
+8. [Information about vulnerabilities](#information-about-vulnerabilities)
+9. [How Gobinsec works](#how-gobinsec-works)
+10. [License](#license)
 
 ## Installation
 
@@ -92,16 +93,18 @@ Configuration file is in YAML format as follows:
 api-key: "28c6112c-a7bc-4a4e-9b14-75be6da02211"
 strict: false
 memcachier:
-  address:    mcx.cy.eu-central-1.ec2.memcachier.com:11211
-  expiration: 86400
-  username:   foo
-  password:   bar
+  address:    "mcx.cy.eu-central-1.ec2.memcachier.com:11211"
+  username:   "username"
+  password:   "password"
+  timeout:    "1s"
+  expiration: "24h"
 memcached:
-  address:    127.0.0.1:11211
-  expiration: 86400
+  address:    "127.0.0.1:11211"
+  timeout:    "1s"
+  expiration: "24h"
 file:
-  name:       ~/.gobinsec-cache.yml
-  expiration: 86400
+  name:       "~/.gobinsec-cache.yml"
+  expiration: "24h"
 ignore:
 - "CVE-2020-14040"
 ```
@@ -110,9 +113,9 @@ Configuration fields are the following:
 
 - **api-key**: this is your NVD API key
 - **strict**: tells if we should consider vulnerability matches without version as matching dependency
-- **memcachier** is the configuration for *memcachier*, with **address**, **expiration** (time in seconds), **username** and **password**
-- **memcached** is the configuration for *memcached*, with **address** and **expiration** time in seconds
-- **file** is the configuration for *file* cache, with **name** and **expiration** time in seconds
+- **memcachier** is the configuration for *memcachier*, see below
+- **memcached** is the configuration for *memcached*, see below
+- **file** is the configuration for *file* cache, see below
 - **ignore**: a list of CVE vulnerabilities to ignore
 
 You can also set NVD API Key in your environment with variable *NVD_API_KEY*. This key may be overwritten with value in configuration file. Your API key must be set in environment to be able to run integration tests (with target *integ*).
@@ -130,21 +133,25 @@ A cache is built with *Memcachier* if following section is found in configuratio
 ```yaml
 memcachier:
   address:    ...
-  expiration: ...
   username:   ...
   password:   ...
+  timeout:    ...
+  expiration: ...
 ```
 
 Else, il will look for following environment variables:
 
 ```
 MEMCACHIER_ADDRESS
-MEMCACHIER_EXPIRATION
 MEMCACHIER_USERNAME
 MEMCACHIER_PASSWORD
+MEMCACHIER_TIMEOUT
+MEMCACHIER_EXPIRATION
 ```
 
 [Memcachier](https://www.memcachier.com) is an online cache provider with free tiers.
+
+*Timeout* and *Expiration* configuration entries are optional and their default values are *1s* and *24h*.
 
 ### Memcached
 
@@ -153,6 +160,7 @@ A cache is built with *Memcached* if following section is found in configuration
 ```yaml
 memcached:
   address:    ...
+  timeout:    ...
   expiration: ...
 ```
 
@@ -160,20 +168,48 @@ Else it will look for following environment variables:
 
 ```
 MEMCACHED_ADDRESS
+MEMCACHED_TIMEOUT
 MEMCACHED_EXPIRATION
 ```
+
+*Timeout* and *Expiration* configuration entries are optional and their default values are *1s* and *24h*.
 
 A sample [docker-compose.yml](https://github.com/intercloud/gobinsec/blob/main/docker-compose.yml) file to start a *memcached* instance is provided in this project.
 
 ### File
 
-If none of preceding configuration is found in configuration and none of related environment variables, *Gobinsec* will use *YAML* file for caching. By default, database file is stored in *~/.gobinsec-cache.yml* and cache duration is of one day (or *86400* seconds). You can overwrite these default values with following configuration section:
+A file cache is used is none of preceding options is configured. By default, database file in YAML format is stored in *~/.gobinsec-cache.yml* and cache duration is of one day (or *24h*). You can overwrite these default values with following configuration section:
 
 ```yaml
 file:
-  name:       "/path/to/file.yml"
-  expiration: 86400
+  name:       "~/.gobinsec-cache.yml"
+  expiration: "24h"
 ```
+
+Or with these environment variables:
+
+```
+FILECACHE_FILE
+FILECACHE_EXPIRATION
+```
+
+*Expiration* configuration entry is optional and its default value is *24h*.
+
+## Timeout and Expiration
+
+These configuration keys are durations with a time unit. Possible units are:
+
+- **ns** for nanosecond
+- **us** or **µs** for microsecond
+- **ms** for millisecond
+- **s** for second
+- **m** for minute
+- **h** for hour
+
+Thus, you could write, for instance:
+
+- *1s* to set timeout to *1* second
+- *2h30m* to set expiration to *2* hours and *30* minutes
 
 ## Versions
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,12 @@ Exit code is *1* if exposed vulnerabilities were found, *2* if there was an erro
 
 You can pass *-verbose* option on command line to print vulnerability report, even if binary is not vulnerable and for all vulnerabilities, even if they are ignored or not exposed.
 
+To print cache information, pass *-cache* on command line. This will print dependencies along with following symbols:
+
+- **>>>** vulnerabilities sent in cache for given dependency
+- **<<<** vulnerabilities retrieved from cache for given dependency
+- **!!!** vulnerabilities missed in cache for given dependency
+
 You can set *-strict* flag on command line so that vulnerabilities without version are considered matching dependency version. In this case, you should check vulnerability manually and disable it in configuration file if necessary.
 
 You can pass configuration file with *-config config.yml*, see configuration section below.

--- a/gobinsec/binary.go
+++ b/gobinsec/binary.go
@@ -79,7 +79,7 @@ func LoadVulnerabilities(dependencies chan *Dependency, wg *sync.WaitGroup) {
 		select {
 		case dependency := <-dependencies:
 			if err := dependency.LoadVulnerabilities(); err != nil {
-				fmt.Printf("ERROR loading vulnerability: %v\n", err)
+				fmt.Fprintf(os.Stderr, "ERROR loading vulnerability: %v\n", err)
 				os.Exit(1)
 			}
 			wg.Done()
@@ -91,17 +91,17 @@ func LoadVulnerabilities(dependencies chan *Dependency, wg *sync.WaitGroup) {
 
 // Report prints a report on terminal
 // nolint:gocyclo // this is life
-func (b *Binary) Report(verbose bool) {
+func (b *Binary) Report() {
 	fmt.Printf("%s: ", filepath.Base(b.Path))
 	if b.Vulnerable {
 		ColorRed.Println("VULNERABLE")
 	} else {
 		ColorGreen.Println("OK")
 	}
-	if len(b.Dependencies) > 0 && (b.Vulnerable || verbose) {
+	if len(b.Dependencies) > 0 && (b.Vulnerable || config.Verbose) {
 		fmt.Println("dependencies:")
 		for _, dependency := range b.Dependencies {
-			if !dependency.Vulnerable && !verbose {
+			if !dependency.Vulnerable && !config.Verbose {
 				continue
 			}
 			fmt.Printf("- name:    '%s'\n", dependency.Name)
@@ -110,7 +110,7 @@ func (b *Binary) Report(verbose bool) {
 			if len(dependency.Vulnerabilities) > 0 {
 				fmt.Println("  vulnerabilities:")
 				for _, vulnerability := range dependency.Vulnerabilities {
-					if !vulnerability.Exposed && !verbose {
+					if !vulnerability.Exposed && !config.Verbose {
 						continue
 					}
 					fmt.Printf("  - id: '%s'\n", vulnerability.ID)

--- a/gobinsec/cache-file.go
+++ b/gobinsec/cache-file.go
@@ -1,40 +1,23 @@
 package gobinsec
 
 import (
+	"fmt"
 	"os"
-	"path/filepath"
-	"strings"
 	"sync"
 	"time"
 
 	"gopkg.in/yaml.v3"
 )
 
+const (
+	FileCacheDefaultFile       = "~/.gobinsec-cache.yml"
+	FileCacheDefaultExpiration = 24 * time.Hour
+)
+
 // FileConfig is the configuration for file cache
 type FileConfig struct {
-	File       string `yaml:"name"`
-	Expiration int32  `yaml:"expiration"`
-}
-
-// NewFileConfig builds configuration for file cache
-func NewFileConfig(config *FileConfig) *FileConfig {
-	if config == nil {
-		config = &FileConfig{}
-	}
-	if config.File == "" {
-		config.File = "~/.gobinsec-cache.yml"
-	}
-	if strings.HasPrefix(config.File, "~/") {
-		home, err := os.UserHomeDir()
-		if err != nil {
-			return nil
-		}
-		config.File = filepath.Join(home, config.File[2:])
-	}
-	if config.Expiration == 0 {
-		config.Expiration = 86400
-	}
-	return config
+	File       string        `yaml:"name"`
+	Expiration time.Duration `yaml:"expiration"`
 }
 
 // DependencyCache is an entry of dependency cache
@@ -46,7 +29,7 @@ type DependencyCache struct {
 // FileCache is the cache instance
 type FileCache struct {
 	File       string
-	Expiration int32
+	Expiration time.Duration
 	Cache      map[string]DependencyCache
 }
 
@@ -54,37 +37,67 @@ type FileCache struct {
 var lock sync.RWMutex
 
 // NewFileCache builds a cache using file
-func NewFileCache(config *FileConfig) Cache {
-	cache := make(map[string]DependencyCache)
-	file, err := os.ReadFile(config.File)
-	if err == nil {
-		if err := yaml.Unmarshal(file, cache); err != nil {
-			cache = make(map[string]DependencyCache)
-		}
+func NewFileCache(config *FileConfig) (Cache, error) {
+	var err error
+	config, err = NewFileConfig(config)
+	if err != nil {
+		return nil, err
 	}
-	fileCache := &FileCache{
+	cache := make(map[string]DependencyCache)
+	fileCache := FileCache{
 		File:       config.File,
 		Expiration: config.Expiration,
 		Cache:      cache,
 	}
-	fileCache.CleanCache()
-	return fileCache
+	return &fileCache, nil
+}
+
+// NewFileConfig builds configuration for file cache
+func NewFileConfig(config *FileConfig) (*FileConfig, error) {
+	if config != nil {
+		if config.File == "" {
+			config.File = FileCacheDefaultFile
+		}
+		if config.Expiration == 0 {
+			config.Expiration = FileCacheDefaultExpiration
+		}
+	} else {
+		file := os.Getenv("FILECACHE_FILE")
+		if file == "" {
+			file = FileCacheDefaultFile
+		}
+		expiration, err := ParseDuration(os.Getenv("FILECACHE_EXPIRATION"), FileCacheDefaultExpiration)
+		if err != nil {
+			return nil, fmt.Errorf("parsing file cache expiration: %v", err)
+		}
+		config = &FileConfig{
+			File:       file,
+			Expiration: expiration,
+		}
+	}
+	config.File = ExpandHome(config.File)
+	return config, nil
+}
+
+// Name returns the name of this cache
+func (fc *FileCache) Name() string {
+	return "File"
 }
 
 // Get returns NVD response for given dependency
-func (fc *FileCache) Get(d *Dependency) []byte {
+func (fc *FileCache) Get(d *Dependency) ([]byte, error) {
 	key := d.Key()
 	lock.RLock()
 	defer lock.RUnlock()
 	dependency, ok := fc.Cache[key]
 	if ok {
-		return []byte(dependency.Vulnerabilities)
+		return []byte(dependency.Vulnerabilities), nil
 	}
-	return nil
+	return nil, nil
 }
 
 // Set put NVD response for given dependency in cache
-func (fc *FileCache) Set(d *Dependency, v []byte) {
+func (fc *FileCache) Set(d *Dependency, v []byte) error {
 	key := d.Key()
 	lock.Lock()
 	defer lock.Unlock()
@@ -94,25 +107,40 @@ func (fc *FileCache) Set(d *Dependency, v []byte) {
 		Vulnerabilities: string(v),
 	}
 	fc.Cache[key] = cache
-}
-
-// Ping does nothing
-func (fc *FileCache) Open() error {
 	return nil
 }
 
-// Clean saves file
-func (fc *FileCache) Close() {
-	text, err := yaml.Marshal(fc.Cache)
-	if err == nil {
-		os.WriteFile(fc.File, text, 0644) // nolint:errcheck,gosec,gomnd // if error writing cache, do nothing
+// Open and load file cache if exists
+func (fc *FileCache) Open() error {
+	if FileExists(fc.File) {
+		file, err := os.ReadFile(fc.File)
+		if err != nil {
+			return fmt.Errorf("reading file cache: %v", err)
+		} else {
+			if err := yaml.Unmarshal(file, fc.Cache); err != nil {
+				return fmt.Errorf("unmarshaling file cache: %v", err)
+			}
+		}
+		fc.CleanCache()
 	}
+	return nil
+}
+
+// Close saves cache in file
+func (fc *FileCache) Close() error {
+	text, err := yaml.Marshal(fc.Cache)
+	if err != nil {
+		return fmt.Errorf("marshaling file cache: %v", err)
+	}
+	if err := os.WriteFile(fc.File, text, 0644); err != nil { // nolint:gosec,gomnd // no confidential data in file
+		return fmt.Errorf("saving file cache: %v", err)
+	}
+	return nil
 }
 
 // CleanCache removes obsolete cache entries
 func (fc *FileCache) CleanCache() {
-	duration := time.Duration(fc.Expiration) * time.Second
-	limit := time.Now().UTC().Add(-duration).Format("2006-01-02T15:04:05")
+	limit := time.Now().UTC().Add(-fc.Expiration).Format("2006-01-02T15:04:05")
 	for name, cache := range fc.Cache {
 		if cache.Date < limit {
 			delete(fc.Cache, name)

--- a/gobinsec/cache-logger.go
+++ b/gobinsec/cache-logger.go
@@ -1,0 +1,56 @@
+package gobinsec
+
+import "fmt"
+
+// CacheLogger logs cache calls on embedded cache
+type CacheLogger struct {
+	Cache Cache
+}
+
+// NewCacheLogger returns a cache logger embedding a cache
+func NewCacheLogger(cache Cache) *CacheLogger {
+	logger := CacheLogger{
+		Cache: cache,
+	}
+	return &logger
+}
+
+// Name return embedded cache name
+func (c *CacheLogger) Name() string {
+	return c.Cache.Name()
+}
+
+// Get calls embedded cache and logs result
+func (c *CacheLogger) Get(d *Dependency) ([]byte, error) {
+	bytes, err := c.Cache.Get(d)
+	if err != nil {
+		return nil, err
+	}
+	if bytes != nil {
+		fmt.Printf("<<< %s\n", d.Name)
+	} else {
+		fmt.Printf("!!! %s\n", d.Name)
+	}
+	return bytes, nil
+}
+
+// Set calls embedded cache and logs call
+func (c *CacheLogger) Set(d *Dependency, v []byte) error {
+	err := c.Cache.Set(d, v)
+	if err != nil {
+		return err
+	}
+	fmt.Printf(">>> %s\n", d.Name)
+	return nil
+}
+
+// Open prints an information message on terminal
+func (c *CacheLogger) Open() error {
+	fmt.Printf("Caching with %s\n", c.Name())
+	return c.Cache.Open()
+}
+
+// Close does nothing
+func (c *CacheLogger) Close() error {
+	return c.Cache.Close()
+}

--- a/gobinsec/cache-memcached.go
+++ b/gobinsec/cache-memcached.go
@@ -1,72 +1,109 @@
 package gobinsec
 
 import (
+	"errors"
+	"fmt"
 	"os"
-	"strconv"
+	"time"
 
 	"github.com/bradfitz/gomemcache/memcache"
 )
 
+const (
+	MemcachedDefaultTimeout    = 1 * time.Second
+	MemcachedDefaultExpiration = 24 * time.Hour
+)
+
 // MemcachedConfig is the configuration for memcached
 type MemcachedConfig struct {
-	Address    string `yaml:"address"`
-	Expiration int32  `yaml:"expiration"`
-}
-
-// NewMemcachedConfig returns configuration
-func NewMemcachedConfig(config *MemcachedConfig) *MemcachedConfig {
-	var address string
-	var expiration int32
-	if config != nil {
-		return config
-	} else if os.Getenv("MEMCACHED_ADDRESS") != "" {
-		address = os.Getenv("MEMCACHED_ADDRESS")
-		exp, err := strconv.Atoi(os.Getenv("MEMCACHED_EXPIRATION")) // nolint:gosec // no overflow possible
-		if err != nil {
-			return nil
-		}
-		expiration = int32(exp)
-		return &MemcachedConfig{
-			Address:    address,
-			Expiration: expiration,
-		}
-	} else {
-		return nil
-	}
+	Address    string        `yaml:"address"`
+	Timeout    time.Duration `yaml:"timeout"`
+	Expiration time.Duration `yaml:"expiration"`
 }
 
 // MemcachedClient is the Cache using memcached
 type MemcachedClient struct {
 	Client     *memcache.Client
-	Expiration int32
+	Expiration time.Duration
 }
 
 // NewMemcachedCache builds a memcached cache
-func NewMemcachedCache(config *MemcachedConfig) Cache {
+func NewMemcachedCache(config *MemcachedConfig) (Cache, error) {
+	config, err := NewMemcachedConfig(config)
+	if err != nil {
+		return nil, err
+	}
+	if config == nil {
+		return nil, nil
+	}
+	client := memcache.New(config.Address)
+	client.Timeout = config.Timeout
 	cache := MemcachedClient{
-		Client:     memcache.New(config.Address),
+		Client:     client,
 		Expiration: config.Expiration,
 	}
-	return &cache
+	return &cache, nil
+}
+
+// NewMemcachedConfig returns configuration
+func NewMemcachedConfig(config *MemcachedConfig) (*MemcachedConfig, error) {
+	if config != nil {
+		if config.Timeout == 0 {
+			config.Timeout = MemcachedDefaultTimeout
+		}
+		if config.Expiration == 0 {
+			config.Expiration = MemcachedDefaultExpiration
+		}
+		return config, nil
+	} else if os.Getenv("MEMCACHED_ADDRESS") != "" {
+		address := os.Getenv("MEMCACHED_ADDRESS")
+		timeout, err := ParseDuration(os.Getenv("MEMCACHED_TIMEOUT"), MemcachedDefaultTimeout)
+		if err != nil {
+			return nil, fmt.Errorf("parsing memcached timeout: %v", err)
+		}
+		expiration, err := ParseDuration(os.Getenv("MEMCACHED_EXPIRATION"), MemcachedDefaultExpiration)
+		if err != nil {
+			return nil, fmt.Errorf("parsing memcached expiration: %v", err)
+		}
+		c := MemcachedConfig{
+			Address:    address,
+			Timeout:    timeout,
+			Expiration: expiration,
+		}
+		return &c, nil
+	} else {
+		return nil, nil
+	}
+}
+
+// Name returns the name of this cache
+func (mc *MemcachedClient) Name() string {
+	return "Memcached"
 }
 
 // Get returns NVD response for given dependency
-func (mc *MemcachedClient) Get(d *Dependency) []byte {
+func (mc *MemcachedClient) Get(d *Dependency) ([]byte, error) {
 	item, err := mc.Client.Get(d.Key())
-	if err != nil {
-		return nil
+	if err != nil && !errors.Is(err, memcache.ErrCacheMiss) {
+		return nil, fmt.Errorf("getting on memcached: %v", err)
 	}
-	return item.Value
+	if item == nil {
+		return nil, nil
+	}
+	return item.Value, nil
 }
 
 // Set put NVD response for given dependency in cache
-func (mc *MemcachedClient) Set(d *Dependency, v []byte) {
+func (mc *MemcachedClient) Set(d *Dependency, v []byte) error {
 	item := memcache.Item{
 		Key:        d.Key(),
 		Value:      v,
-		Expiration: mc.Expiration,
+		Expiration: int32(mc.Expiration.Seconds()),
 	}
-	mc.Client.Set(&item) // nolint:errcheck // we ignore error
+	if err := mc.Client.Set(&item); err != nil {
+		return fmt.Errorf("setting on memcached: %v", err)
+	}
+	return nil
 }
 
 // Ping calls memcached
@@ -75,5 +112,6 @@ func (mc *MemcachedClient) Open() error {
 }
 
 // Clean does nothing
-func (mc *MemcachedClient) Close() {
+func (mc *MemcachedClient) Close() error {
+	return nil
 }

--- a/gobinsec/cache-memcachier.go
+++ b/gobinsec/cache-memcachier.go
@@ -1,80 +1,118 @@
 package gobinsec
 
 import (
+	"errors"
+	"fmt"
 	"os"
-	"strconv"
+	"time"
 
 	"github.com/memcachier/gomemcache/memcache"
 )
 
+const (
+	MemcachierDefaultTimeout    = 1 * time.Second
+	MemcachierDefaultExpiration = 24 * time.Hour
+)
+
 // MemcachierConfig is the configuration for Memcachier
 type MemcachierConfig struct {
-	Address    string `yaml:"address"`
-	Expiration int32  `yaml:"expiration"`
-	Username   string `yaml:"username"`
-	Password   string `yaml:"password"`
+	Address    string        `yaml:"address"`
+	Username   string        `yaml:"username"`
+	Password   string        `yaml:"password"`
+	Timeout    time.Duration `yaml:"timeout"`
+	Expiration time.Duration `yaml:"expiration"`
 }
 
 // MemcachierClient is the Cache using Memcachier
 type MemcachierClient struct {
 	Client     *memcache.Client
-	Expiration int32
-}
-
-// NewMemcachierConfig returns configuration
-func NewMemcachierConfig(config *MemcachierConfig) *MemcachierConfig {
-	var username, password, address string
-	var expiration int32
-	if config != nil {
-		return config
-	} else if os.Getenv("MEMCACHIER_ADDRESS") != "" {
-		username = os.Getenv("MEMCACHIER_USERNAME")
-		password = os.Getenv("MEMCACHIER_PASSWORD")
-		address = os.Getenv("MEMCACHIER_ADDRESS")
-		exp, err := strconv.Atoi(os.Getenv("MEMCACHIER_EXPIRATION")) // nolint:gosec // no overflow possible
-		if err != nil {
-			return nil
-		}
-		expiration = int32(exp)
-		return &MemcachierConfig{
-			Address:    address,
-			Expiration: expiration,
-			Username:   username,
-			Password:   password,
-		}
-	} else {
-		return nil
-	}
+	Expiration time.Duration
 }
 
 // NewMemcachierCache builds a Memcachier cache
-func NewMemcachierCache(config *MemcachierConfig) Cache {
+func NewMemcachierCache(config *MemcachierConfig) (Cache, error) {
+	config, err := NewMemcachierConfig(config)
+	if err != nil {
+		return nil, err
+	}
+	if config == nil {
+		return nil, nil
+	}
 	client := memcache.New(config.Address)
 	client.SetAuth(config.Username, []byte(config.Password))
+	client.Timeout = config.Timeout
 	cache := MemcachierClient{
 		Client:     client,
 		Expiration: config.Expiration,
 	}
-	return &cache
+	return &cache, nil
+}
+
+// NewMemcachierConfig returns configuration
+func NewMemcachierConfig(config *MemcachierConfig) (*MemcachierConfig, error) {
+	if config != nil {
+		if config.Timeout == 0 {
+			config.Timeout = MemcachierDefaultTimeout
+		}
+		if config.Expiration == 0 {
+			config.Expiration = MemcachierDefaultExpiration
+		}
+		return config, nil
+	} else if os.Getenv("MEMCACHIER_ADDRESS") != "" &&
+		os.Getenv("MEMCACHIER_USERNAME") != "" &&
+		os.Getenv("MEMCACHIER_PASSWORD") != "" {
+		address := os.Getenv("MEMCACHIER_ADDRESS")
+		username := os.Getenv("MEMCACHIER_USERNAME")
+		password := os.Getenv("MEMCACHIER_PASSWORD")
+		timeout, err := ParseDuration(os.Getenv("MEMCACHIER_TIMEOUT"), MemcachierDefaultTimeout)
+		if err != nil {
+			return nil, fmt.Errorf("parsing memcachier timeout: %v", err)
+		}
+		expiration, err := ParseDuration(os.Getenv("MEMCACHIER_EXPIRATION"), MemcachierDefaultExpiration)
+		if err != nil {
+			return nil, fmt.Errorf("parsing memcachier expiration: %v", err)
+		}
+		c := MemcachierConfig{
+			Address:    address,
+			Username:   username,
+			Password:   password,
+			Timeout:    timeout,
+			Expiration: expiration,
+		}
+		return &c, nil
+	} else {
+		return nil, nil
+	}
+}
+
+// Name returns the name of this cache
+func (mc *MemcachierClient) Name() string {
+	return "Memcachier"
 }
 
 // Get returns NVD response for given dependency
-func (mc *MemcachierClient) Get(d *Dependency) []byte {
+func (mc *MemcachierClient) Get(d *Dependency) ([]byte, error) {
 	item, err := mc.Client.Get(d.Key())
-	if err != nil {
-		return nil
+	if err != nil && !errors.Is(err, memcache.ErrCacheMiss) {
+		return nil, fmt.Errorf("getting on memcachier: %v", err)
 	}
-	return item.Value
+	if item == nil {
+		return nil, nil
+	}
+	return item.Value, nil
 }
 
 // Set put NVD response for given dependency in cache
-func (mc *MemcachierClient) Set(d *Dependency, v []byte) {
+func (mc *MemcachierClient) Set(d *Dependency, v []byte) error {
 	item := memcache.Item{
 		Key:        d.Key(),
 		Value:      v,
-		Expiration: mc.Expiration,
+		Expiration: int32(mc.Expiration.Seconds()),
 	}
-	mc.Client.Set(&item) // nolint:errcheck // we ignore error
+	if err := mc.Client.Set(&item); err != nil {
+		return fmt.Errorf("setting on memcachier: %v", err)
+	}
+	return nil
 }
 
 // Ping calls Memcachier
@@ -82,11 +120,12 @@ func (mc *MemcachierClient) Open() error {
 	item := memcache.Item{
 		Key:        "test",
 		Value:      []byte("test"),
-		Expiration: mc.Expiration,
+		Expiration: int32(mc.Expiration.Seconds()),
 	}
 	return mc.Client.Set(&item)
 }
 
 // Clean does nothing
-func (mc *MemcachierClient) Close() {
+func (mc *MemcachierClient) Close() error {
+	return nil
 }

--- a/gobinsec/config.go
+++ b/gobinsec/config.go
@@ -14,14 +14,18 @@ type Config struct {
 	File       *FileConfig       `yaml:"file"`
 	Ignore     []string          `yaml:"ignore"`
 	Strict     bool              `yaml:"strict"`
+	Verbose    bool              `yaml:"verbose"`
+	Cache      bool              `yaml:"cache"`
 }
 
 var config Config
 
 // LoadConfig loads configuration from given file
-func LoadConfig(path string, strict bool) error {
+func LoadConfig(path string, strict, verbose, cache bool) error {
 	if path == "" {
 		config.Strict = strict
+		config.Verbose = verbose
+		config.Cache = cache
 		return nil
 	}
 	bytes, err := os.ReadFile(path)
@@ -37,6 +41,8 @@ func LoadConfig(path string, strict bool) error {
 	if strict {
 		config.Strict = strict
 	}
+	config.Verbose = verbose
+	config.Cache = cache
 	return nil
 }
 

--- a/gobinsec/dependency.go
+++ b/gobinsec/dependency.go
@@ -32,7 +32,10 @@ func NewDependency(name, version string) (*Dependency, error) {
 
 // Vulnerabilities return list of vulnerabilities for given dependency
 func (d *Dependency) LoadVulnerabilities() error {
-	vulnerabilities := CacheInstance.Get(d)
+	vulnerabilities, err := CacheInstance.Get(d)
+	if err != nil {
+		return err
+	}
 	if vulnerabilities == nil {
 		url := URL + d.Name
 		if config.APIKey != "" {
@@ -50,7 +53,9 @@ func (d *Dependency) LoadVulnerabilities() error {
 		if err != nil {
 			return err
 		}
-		CacheInstance.Set(d, vulnerabilities)
+		if err := CacheInstance.Set(d, vulnerabilities); err != nil {
+			return err
+		}
 	}
 	var result Response
 	if err := json.Unmarshal(vulnerabilities, &result); err != nil {

--- a/gobinsec/utils.go
+++ b/gobinsec/utils.go
@@ -2,8 +2,11 @@ package gobinsec
 
 import (
 	"bytes"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
+	"time"
 )
 
 // ExecCommand runs command with given args and returns stdout, stderr and an error if any
@@ -17,4 +20,33 @@ func ExecCommand(name string, args ...string) (stdout, stderr string, err error)
 	stdout = strings.TrimSpace(outBytes.String())
 	stderr = strings.TrimSpace(errBytes.String())
 	return
+}
+
+// FileExists tells if given file exists
+func FileExists(file string) bool {
+	info, err := os.Stat(file)
+	if os.IsNotExist(err) {
+		return false
+	}
+	return !info.IsDir()
+}
+
+// ExpandHome expand ~ in file path with home directory
+func ExpandHome(file string) string {
+	if strings.HasPrefix(file, "~/") {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return file
+		}
+		file = filepath.Join(home, file[2:])
+	}
+	return file
+}
+
+// ParseDuration with default value
+func ParseDuration(value string, def time.Duration) (time.Duration, error) {
+	if value == "" {
+		return def, nil
+	}
+	return time.ParseDuration(value)
 }

--- a/test/config-file.yml
+++ b/test/config-file.yml
@@ -1,6 +1,6 @@
 api-key:   "${NVD_API_KEY}"
 file:
   name:       "~/.gobinsec-cache.yml"
-  expiration: 86400
+  expiration: "24h"
 ignore:
 - "CVE-2020-14040"

--- a/test/config-memcached.yml
+++ b/test/config-memcached.yml
@@ -1,6 +1,7 @@
 api-key:   "${NVD_API_KEY}"
 memcached:
-  address:    127.0.0.1:11211
-  expiration: 86400
+  address:    "127.0.0.1:11211"
+  timeout:    "1s"
+  expiration: "24h"
 ignore:
 - "CVE-2020-14040"

--- a/test/config-memcachier.yml
+++ b/test/config-memcachier.yml
@@ -1,8 +1,9 @@
 api-key:   "${NVD_API_KEY}"
 memcachier:
-  address:    mcx.cy.eu-central-1.ec2.memcachier.com:11211
-  expiration: 86400
-  username:   foo
-  password:   bar
+  address:    "mcx.cy.eu-central-1.ec2.memcachier.com:11211"
+  username:   "username"
+  password:   "password"
+  timeout:    "1s"
+  expiration: "24h"
 ignore:
 - "CVE-2020-14040"


### PR DESCRIPTION
New features:

- Added `-cache` command line option to print cache information
- Added timeout configuration

Timeout and Expiration configuration entries now have units. Thus:

- To set one second timeout, you would write `1s`
- To set expiration of two hours and thirty minutes, you would write `2h30m`